### PR TITLE
Fix npm dev command path instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ cd LuxHub
 ### 2. Frontend Setup
 ```bash
 cd frontend
+# All npm scripts live here. Running them from the repo root will cause
+# "ENOENT: no such file or directory, open 'package.json'" errors.
 npm install
 npm run dev
 ```


### PR DESCRIPTION
## Summary
- clarify that npm scripts must be run from the `frontend` folder to avoid ENOENT errors

## Testing
- `npm run dev` from `frontend` (started Vite server)


------
https://chatgpt.com/codex/tasks/task_b_688874c6bdf0832eadda261829a43fc8